### PR TITLE
Habitize v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _bin/
 _pkg/
 _src/
 habitat/results/
+results/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ aws-signing-proxy
 _bin/
 _pkg/
 _src/
+habitat/results/

--- a/habitat/config/aws-signing-proxy.yml
+++ b/habitat/config/aws-signing-proxy.yml
@@ -1,0 +1,4 @@
+listen-address: {{cfg.listen_address}}
+port: {{cfg.port}}
+target: {{cfg.target}}
+region: {{cfg.region}}

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,4 @@
+listen_address = "0.0.0.0"
+port = 9200
+target = "http://myawsservice.amazonaws.com"
+region = "us-east-1"

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+exec 2>&1
+
+cd {{pkg.svc_config_path}}
+
+exec aws-signing-proxy

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,66 @@
+pkg_name=aws-signing-proxy
+pkg_origin=irvingpop
+pkg_version="0.3.0"
+pkg_maintainer="The Chef Automate Maintainers <support@chef.io>"
+pkg_license=('MIT')
+pkg_source="https://github.com/nsdavidson/aws-signing-proxy.git"
+pkg_dirname="$pkg_name"
+pkg_deps=( )
+pkg_build_deps=(
+  core/git
+  core/go
+)
+pkg_bin_dirs=(bin)
+pkg_exports=(
+  [port]=port
+)
+pkg_exposes=(port)
+pkg_description="AWS Signing Proxy for ElasticSearch"
+pkg_upstream_url="https://github.com/nsdavidson/aws-signing-proxy"
+# pkg_binds_optional=(
+#   [elasticsearch]="http-port"
+# )
+
+do_clean() {
+  return 0
+}
+
+do_download() {
+  rm -rf "$CACHE_PATH"
+  git clone "$pkg_source" "$CACHE_PATH" --depth 1
+}
+
+do_verify() {
+  return 0
+}
+
+do_unpack() {
+  return 0
+}
+
+do_prepare() {
+  mkdir -pv "$CACHE_PATH/cache"
+  export GOPATH="$CACHE_PATH/cache"
+  build_line "Setting GOPATH=$GOPATH"
+  export PATH="$PATH:$GOPATH/bin"
+  build_line "Setting PATH=$PATH"
+  export GOOS=linux
+  build_line "Setting GOOS=$GOOS"
+  GOARCH=amd64
+  build_line "Setting GOARCH=$GOARCH"
+}
+
+do_build() {
+  go get github.com/Masterminds/glide
+  glide up
+  glide install
+  mkdir -pv "$CACHE_PATH/vendor/src"
+  mv "$CACHE_PATH/vendor/"*.* "$CACHE_PATH/vendor/src"
+  export GOPATH="$CACHE_PATH/vendor"
+  build_line "Setting GOPATH=$GOPATH"
+  go build -ldflags "-X main.VERSION=$pkg_version" -o "$pkg_prefix/bin/aws-signing-proxy" $CACHE_PATH/main.go
+}
+
+do_install() {
+  return 0
+}

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=aws-signing-proxy
 pkg_origin=irvingpop
-pkg_version="0.3.0"
+pkg_version="0.2.0"
 pkg_maintainer="The Chef Automate Maintainers <support@chef.io>"
 pkg_license=('MIT')
 pkg_source="https://github.com/nsdavidson/aws-signing-proxy.git"
@@ -12,14 +12,11 @@ pkg_build_deps=(
 )
 pkg_bin_dirs=(bin)
 pkg_exports=(
-  [port]=port
+  [http-port]=port
 )
-pkg_exposes=(port)
+pkg_exposes=(http-port)
 pkg_description="AWS Signing Proxy for ElasticSearch"
 pkg_upstream_url="https://github.com/nsdavidson/aws-signing-proxy"
-# pkg_binds_optional=(
-#   [elasticsearch]="http-port"
-# )
 
 do_clean() {
   return 0
@@ -27,7 +24,7 @@ do_clean() {
 
 do_download() {
   rm -rf "$CACHE_PATH"
-  git clone "$pkg_source" "$CACHE_PATH" --depth 1
+  git clone "$pkg_source" "$CACHE_PATH" --depth 1 --branch "v$pkg_version"
 }
 
 do_verify() {


### PR DESCRIPTION
First pass at habitizing this.   There are some problems:
- Now that logging *expects* to create a `/var/log/aws-signing-proxy` folder and log there, that makes a habitized/containerized version of this very mad
- Hard to test on your laptop, cause it wants to grab AWS credentials.  I wonder if environment variables should be set to help that.

what it looks like when you run it:
```
hab-sup(MR): Supervisor Member-ID 24a7f67fbe5b48ce8f4df0da63759fe6
hab-sup(MR): Starting irving/aws-signing-proxy
hab-sup(MR): Starting gossip-listener on 0.0.0.0:9638
hab-sup(MR): Starting http-gateway on 0.0.0.0:9631
aws-signing-proxy.default(SR): Hooks recompiled
default(CF): Updated aws-signing-proxy.yml c33edc89149e279b4e196f3831ec14087cb9e0154de888de1350ed5aa3800b95
aws-signing-proxy.default(SR): Configuration recompiled
aws-signing-proxy.default(SR): Initializing
aws-signing-proxy.default(SV): Starting service as user=hab, group=hab
aws-signing-proxy.default(O): 2017-08-17 23:28:02.260660315 +0000 UTC write error: can't make directories for new logfile: mkdir /var/log/aws-signing-proxy: permission denied
aws-signing-proxy.default(O): NoCredentialProviders: no valid providers in chain. Deprecated.
aws-signing-proxy.default(O): 	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
aws-signing-proxy.default(SV): Starting service as user=hab, group=hab
aws-signing-proxy.default(O): 2017-08-17 23:28:13.194918622 +0000 UTC write error: can't make directories for new logfile: mkdir /var/log/aws-signing-proxy: permission denied
aws-signing-proxy.default(O): NoCredentialProviders: no valid providers in chain. Deprecated.
aws-signing-proxy.default(O): 	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
aws-signing-proxy.default(SV): Starting service as user=hab, group=hab
...
```