### PR TITLE
Adds options for config file and log location

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ var idleConnTimeout = flag.Int("idle-conn-timeout", 90, "the maximum amount of t
 var dialTimeout = flag.Int("dial-timeout", 30, "The maximum amount of time a dial will wait for a connect to complete.")
 var dialKeepAlive = flag.Int("dial-keep-alive", 30, "The amount of time a dial will keep a connection alive for.")
 var logLevel = flag.String("log-level", "info", "Log level.  Default is info.  May also be set to 'debug'.")
+var logLocation = flag.String("log-location", "/var/log/aws-signing-proxy", "The location to write the log file to.")
+var configLocation = flag.String("config-location", "/etc", "The location of the aws-signing-proxy.")
 
 type configuration struct {
 	Target          string `mapstructure:"target"`
@@ -46,6 +48,7 @@ type configuration struct {
 	DialTimeout     int    `mapstructure:"dial-timeout"`
 	DialKeepAlive   int    `mapstructure:"dial-keep-alive"`
 	LogLevel        string `mapstructure:"log-level"`
+	LogLocation     string `mapstructure:"log-location"`
 }
 
 var config configuration
@@ -174,7 +177,7 @@ func main() {
 
 	// Viper setup
 	viper.SetConfigName("aws-signing-proxy")
-	viper.AddConfigPath("/etc/")
+	viper.AddConfigPath(*configLocation)
 	viper.AddConfigPath(".")
 	viper.ReadInConfig()
 
@@ -211,7 +214,7 @@ func main() {
 
 	// Setup lumberjack for rotation
 	w := zapcore.AddSync(&lumberjack.Logger{
-		Filename:   "/var/log/aws-signing-proxy/proxy.log",
+		Filename:   config.LogLocation + "/proxy.log",
 		MaxSize:    100,
 		MaxBackups: 3,
 	})


### PR DESCRIPTION
This changes makes both the location of the config file and the log
files configurable.

You can set a custom config path at the command line.  By default, it
will be `/etc`.  This value should be a path to a directory.  Within
that directory, the app will look for `aws-signing-proxy.yml` (the file
name itself is still hard coded). The cli option is `--config-location`.

A custom log location can be set at the command line or through the
config file.  By default it will be `/var/log/aws-signing-proxy`.  This
value should also be a path to a directory.  Within the specified
directory, the app will create a `proxy.log` and take care of log
rotation.  The CLI option is `--log-location` and the config entry is
`log-location`.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>