### PR TITLE
Making file/stdout logging configurable.

### DIFF
--- a/habitat/config/aws-signing-proxy.yml
+++ b/habitat/config/aws-signing-proxy.yml
@@ -2,3 +2,5 @@ listen-address: {{cfg.listen_address}}
 port: {{cfg.port}}
 target: {{cfg.target}}
 region: {{cfg.region}}
+no-file-log: {{cfg.filelog}}
+stdout-log: {{cfg.stdoutlog}}

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -2,3 +2,5 @@ listen_address = "0.0.0.0"
 port = 9200
 target = "http://myawsservice.amazonaws.com"
 region = "us-east-1"
+filelog = false
+stdout-log = true

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -4,4 +4,4 @@ exec 2>&1
 
 cd {{pkg.svc_config_path}}
 
-exec aws-signing-proxy
+exec aws-signing-proxy --config-location {{pkg.svc_config_path}}


### PR DESCRIPTION
By default, logs will be logged to file and not stdout.  File logging
can be disabled with the `no-file-log` CLI/config file option.
Logging to stdout can be enabled with `stdout-log`.

Updated the habitat plan to turn off file logging and enable stdout.
