### PR TITLE
Bump version, fix some typos and set sane defaults for containers in the habitat configs

### DIFF
--- a/habitat/config/aws-signing-proxy.yml
+++ b/habitat/config/aws-signing-proxy.yml
@@ -2,5 +2,5 @@ listen-address: {{cfg.listen_address}}
 port: {{cfg.port}}
 target: {{cfg.target}}
 region: {{cfg.region}}
-no-file-log: {{cfg.filelog}}
-stdout-log: {{cfg.stdoutlog}}
+no-file-log: {{cfg.no-file-log}}
+stdout-log: {{cfg.stdout-log}}

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -2,5 +2,6 @@ listen_address = "0.0.0.0"
 port = 9200
 target = "http://myawsservice.amazonaws.com"
 region = "us-east-1"
-filelog = false
+log-level = "info"
+no-file-log = true
 stdout-log = true

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=aws-signing-proxy
 pkg_origin=irvingpop
-pkg_version="0.2.0"
+pkg_version="0.5.0"
 pkg_maintainer="The Chef Automate Maintainers <support@chef.io>"
 pkg_license=('MIT')
 pkg_source="https://github.com/nsdavidson/aws-signing-proxy.git"


### PR DESCRIPTION

this is pushed to dockerhub as `irvingpop/aws-signing-proxy:0.5.0-20170825001652` and tagged to `:latest` 